### PR TITLE
chore(ci): detect stale OpenAPI schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Missing migrations
         run: task db:migrations:check
 
+      # Zmieniony serializer bez regeneracji schematu nie psuje żadnego testu —
+      # rozjazd wychodzi dopiero, gdy klient frontendu przestaje pasować do API.
+      - name: API schema up to date
+        run: task backend:schema:check
+
       - name: Backend tests
         run: task test:backend-local -- src/ -m "not integration"
 

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,10 @@ backend/src/media/
 backend/src/mediafiles/
 backend/src/staticfiles/
 
+# Plik roboczy `task backend:schema:check` — porównywana kopia schematu.
+# Zadanie sprząta go samo, wpis jest na wypadek przerwania w połowie.
+backend/.schema-check.yaml
+
 # Taskfile cache ignore
 .task/
 

--- a/backend/src/schema.yaml
+++ b/backend/src/schema.yaml
@@ -1664,6 +1664,10 @@ components:
     PatchedProfile:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
         email:
           type: string
           format: email
@@ -1697,6 +1701,10 @@ components:
     Profile:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
         email:
           type: string
           format: email
@@ -1731,6 +1739,7 @@ components:
       - age
       - email
       - fullName
+      - id
       - role
     RoleEnum:
       enum:

--- a/taskfiles/backend.yml
+++ b/taskfiles/backend.yml
@@ -3,6 +3,37 @@
 version: "3"
 
 tasks:
+    schema:generate:
+        desc: Regenerate OpenAPI schema from the code (task backend:schema:generate)
+        dir: backend
+        env:
+            # drf-spectacular siedzi w INSTALLED_APPS tylko w development.py,
+            # więc komenda `spectacular` istnieje wyłącznie w tym środowisku.
+            # Samo generowanie nie dotyka bazy, więc chodzi też na czystym runnerze.
+            DJANGO_ENVIRONMENT: development
+            DJANGO_DEBUG: "1"
+        cmds:
+            - uv run python src/manage.py spectacular --file src/schema.yaml
+
+    schema:check:
+        desc: Fail if schema.yaml is stale versus the code (task backend:schema:check)
+        dir: backend
+        env:
+            DJANGO_ENVIRONMENT: development
+            DJANGO_DEBUG: "1"
+        cmds:
+            # Ten sam wzorzec co `db:migrations:check`: generujemy obok i porównujemy,
+            # zamiast ufać, że ktoś pamiętał o regeneracji po zmianie serializera.
+            # Rozjazd schematu nie psuje testów — wychodzi dopiero, gdy klient
+            # frontendu przestaje pasować do API.
+            #
+            # `spectacular` zapisuje schemat wyłącznie przez `--file` (bez tej flagi na
+            # stdout nie trafia nic), więc porównanie idzie przez plik obok. `defer`
+            # sprząta go także wtedy, gdy diff zwróci różnicę i zadanie padnie.
+            - uv run python src/manage.py spectacular --file .schema-check.yaml
+            - defer: rm -f .schema-check.yaml
+            - diff -u src/schema.yaml .schema-check.yaml
+
     run:
         desc: Run Django app and microservices
         cmds:


### PR DESCRIPTION
Closes #7

> **Bazuje na #6.** Gałąź bazowa to `fix/5-ci-green-pipeline`, żeby diff pokazywał tylko zmiany tego PR-a. Po zmergowaniu #6 GitHub przestawi bazę na `master` sam.

## Problem

`backend/src/schema.yaml` leży w repo, ale nic nie pilnuje jego zgodności z kodem. Zmiana serializera bez `task backend:schema:generate` nie psuje żadnego testu — rozjazd wychodzi dopiero wtedy, gdy wygenerowany klient frontendu przestaje pasować do API.

**Rozjazd już był.** Zacommitowany schemat kontra wygenerowany z bieżącego kodu:

```diff
-      email:
+      id:
-        format: email
+        format: uuid
+        readOnly: true
```

Serializer profilu ma `id` typu UUID i `email` jako `readOnly`, czego `schema.yaml` nie znał. Ten PR zawiera regenerację, więc plik znów odpowiada kodowi.

## Rozwiązanie

Ten sam wzorzec co `db:migrations:check` z #5 — generujemy obok i porównujemy, zamiast ufać, że ktoś pamiętał.

| Co | Gdzie |
| --- | --- |
| `task backend:schema:generate` | regeneracja schematu z kodu |
| `task backend:schema:check` | porównanie; błąd przy różnicy |
| krok `API schema up to date` | job Backend, zaraz po kontroli migracji |

## Dwie rzeczy, na które się natknąłem

**`drf-spectacular` jest w `INSTALLED_APPS` tylko w `development.py`** — w środowisku `testing` komenda `spectacular` po prostu nie istnieje. Zadania ustawiają więc `DJANGO_ENVIRONMENT=development`; samo generowanie nie dotyka bazy, więc czysty runner wystarczy.

**Schemat zapisuje się wyłącznie przez `--file`** — bez tej flagi na stdout nie trafia nic, więc `| diff -` nie zadziała. Porównanie idzie przez plik obok, sprzątany przez `defer` także wtedy, gdy diff zwróci różnicę i zadanie padnie. `mktemp` odpadł, bo Task na Windows nie potrafi otworzyć zwracanej przez niego ścieżki POSIX.

## Weryfikacja

| Test | Wynik |
| --- | --- |
| `schema:check` przed regeneracją | **fail** (wykrył istniejący drift) |
| `schema:check` po regeneracji | pass |
| test negatywny: podmiana `version` w schemacie | **fail** |
| przywrócenie schematu | pass |
| plik roboczy po nieudanym checku | posprzątany |
| `ruff`, `pyrefly`, `db:migrations:check` | pass |

## Uwaga na przyszłość

Orval bierze schemat z **żywego URL-a** (`/api/schema/`), nie z tego pliku — `schema.yaml` jest dziś dokumentacją, a kontrola pilnuje, żeby nie kłamała. Gdyby generator miał kiedyś czytać plik z repo, ta kontrola staje się krytyczna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)