### PR TITLE
chore(ci): enable Dependabot for actions, Python and Bun

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+version: 2
+
+updates:
+  # Akcje w workflowach nie mają lockfile'a — wersję trzyma sam plik YAML, więc bez
+  # tego nikt nigdy nie podniesie `actions/checkout@v4`. Tu podatność uderza wprost
+  # w pipeline, który ma dostęp do repozytorium.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(ci)
+
+  # Dependabot nie obsługuje ekosystemu `uv`, ale czyta zależności z pyproject.toml
+  # przez `pip`. Skutek: dostaniesz PR-y podnoszące wersje w pyproject, natomiast
+  # `uv.lock` trzeba odświeżyć samemu (`uv lock`) przed zmergowaniem.
+  - package-ecosystem: pip
+    directory: /backend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      # Aktualizacje łatek osobno na paczkę to szum. Zgrupowane wchodzą jednym PR-em,
+      # a wersje minor i major zostają pojedynczo, bo tam trzeba przeczytać changelog.
+      python-patch:
+        update-types:
+          - patch
+
+  # Bun jest wspierany od wersji 1.1.39 — projekt używa nowszej, więc `bun.lock`
+  # zostanie zaktualizowany razem z package.json.
+  - package-ecosystem: bun
+    directory: /frontend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      js-patch:
+        update-types:
+          - patch
+    ignore:
+      # Wersje Expo, Reacta i React Native są związane z konkretnym SDK Expo —
+      # podnoszenie ich pojedynczo rozjeżdża projekt. Te idą razem z upgradem SDK,
+      # ręcznie, według przewodnika migracji.
+      - dependency-name: expo
+      - dependency-name: expo-*
+      - dependency-name: react
+      - dependency-name: react-dom
+      - dependency-name: react-native
+      - dependency-name: react-native-*


### PR DESCRIPTION
Closes #9

> **Bazuje na #8** (które bazuje na #6). Po zmergowaniu tamtych GitHub przestawi bazę sam.

## Po co

Nic nie pilnuje wersji zależności ani akcji w workflowach. Przy `github-actions` boli to najbardziej: akcje nie mają lockfile'a — wersję trzyma sam YAML, więc bez automatu `actions/checkout@v4` zostanie na v4 na zawsze. Podatność w akcji uderza wprost w pipeline mający dostęp do repozytorium.

## Konfiguracja

| Ekosystem | Katalog | Uwaga |
| --- | --- | --- |
| `github-actions` | `/` | wersje akcji w workflowach |
| `pip` | `/backend` | Dependabot **nie obsługuje `uv`** — czyta zależności z `pyproject.toml` |
| `bun` | `/frontend` | wspierany od Bun 1.1.39; projekt używa 1.3.13 |

Sprawdzone w dokumentacji GitHuba, nie z pamięci: ekosystemu `uv` na liście nie ma, `bun` i `github-actions` są.

Łatki zgrupowane w jeden PR — pojedynczo są szumem. Minor i major osobno, bo tam trzeba przeczytać changelog.

## Co świadomie wyłączone

`expo`, `expo-*`, `react`, `react-dom`, `react-native`, `react-native-*` — ich wersje są związane z konkretnym SDK Expo. Podnoszenie pojedynczo rozjeżdża projekt; te idą razem z upgradem SDK, ręcznie, według przewodnika migracji.

## Ograniczenie do zapamiętania

Ekosystem `pip` podniesie `pyproject.toml`, ale **nie `uv.lock`**. Przed zmergowaniem takiego PR-a trzeba zrobić `uv lock` — inaczej CI zainstaluje stare wersje mimo podbitego pyproject. Zapisane też w komentarzu w pliku, żeby nie zgubiło się przy pierwszym takim PR-ze.

## Dlaczego to, a nie testy integracyjne

Testy integracyjne zapowiadałem jako następny krok, ale po sprawdzeniu kodu odpuściłem:

- W `testing.py` baza to SQLite in-memory, a cache to `LocMemCache`. Health check bada DB, Redis i S3 — ale w tym środowisku dwa pierwsze są w pamięci procesu.
- Z 3 testów z markerem `integration` realnie „integracyjne" zostaje jedno wywołanie `head_bucket` na S3.
- `docker-compose.test.yml` wymaga katalogu `.envs/`, którego nie ma w repo.

Koszt (MinIO w pipelinie, zmienne, tworzenie bucketu, ryzyko flaky) nie odpowiada zyskowi. Sensowniej najpierw przenieść bazę i cache w tych testach na realne usługi — wtedy marker `integration` zacznie znaczyć to, co obiecuje, i dopiero wtedy warto go włączać do CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)