### PR TITLE
chore(ci): recover schema drift check and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+version: 2
+
+updates:
+  # Akcje w workflowach nie mają lockfile'a — wersję trzyma sam plik YAML, więc bez
+  # tego nikt nigdy nie podniesie `actions/checkout@v4`. Tu podatność uderza wprost
+  # w pipeline, który ma dostęp do repozytorium.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(ci)
+
+  # Dependabot nie obsługuje ekosystemu `uv`, ale czyta zależności z pyproject.toml
+  # przez `pip`. Skutek: dostaniesz PR-y podnoszące wersje w pyproject, natomiast
+  # `uv.lock` trzeba odświeżyć samemu (`uv lock`) przed zmergowaniem.
+  - package-ecosystem: pip
+    directory: /backend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      # Aktualizacje łatek osobno na paczkę to szum. Zgrupowane wchodzą jednym PR-em,
+      # a wersje minor i major zostają pojedynczo, bo tam trzeba przeczytać changelog.
+      python-patch:
+        update-types:
+          - patch
+
+  # Bun jest wspierany od wersji 1.1.39 — projekt używa nowszej, więc `bun.lock`
+  # zostanie zaktualizowany razem z package.json.
+  - package-ecosystem: bun
+    directory: /frontend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      js-patch:
+        update-types:
+          - patch
+    ignore:
+      # Wersje Expo, Reacta i React Native są związane z konkretnym SDK Expo —
+      # podnoszenie ich pojedynczo rozjeżdża projekt. Te idą razem z upgradem SDK,
+      # ręcznie, według przewodnika migracji.
+      - dependency-name: expo
+      - dependency-name: expo-*
+      - dependency-name: react
+      - dependency-name: react-dom
+      - dependency-name: react-native
+      - dependency-name: react-native-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Missing migrations
         run: task db:migrations:check
 
+      # Zmieniony serializer bez regeneracji schematu nie psuje żadnego testu —
+      # rozjazd wychodzi dopiero, gdy klient frontendu przestaje pasować do API.
+      - name: API schema up to date
+        run: task backend:schema:check
+
       - name: Backend tests
         run: task test:backend-local -- src/ -m "not integration"
 

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,10 @@ backend/src/media/
 backend/src/mediafiles/
 backend/src/staticfiles/
 
+# Plik roboczy `task backend:schema:check` — porównywana kopia schematu.
+# Zadanie sprząta go samo, wpis jest na wypadek przerwania w połowie.
+backend/.schema-check.yaml
+
 # Taskfile cache ignore
 .task/
 

--- a/backend/src/schema.yaml
+++ b/backend/src/schema.yaml
@@ -1664,6 +1664,10 @@ components:
     PatchedProfile:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
         email:
           type: string
           format: email
@@ -1697,6 +1701,10 @@ components:
     Profile:
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
         email:
           type: string
           format: email
@@ -1731,6 +1739,7 @@ components:
       - age
       - email
       - fullName
+      - id
       - role
     RoleEnum:
       enum:

--- a/taskfiles/backend.yml
+++ b/taskfiles/backend.yml
@@ -3,6 +3,37 @@
 version: "3"
 
 tasks:
+    schema:generate:
+        desc: Regenerate OpenAPI schema from the code (task backend:schema:generate)
+        dir: backend
+        env:
+            # drf-spectacular siedzi w INSTALLED_APPS tylko w development.py,
+            # więc komenda `spectacular` istnieje wyłącznie w tym środowisku.
+            # Samo generowanie nie dotyka bazy, więc chodzi też na czystym runnerze.
+            DJANGO_ENVIRONMENT: development
+            DJANGO_DEBUG: "1"
+        cmds:
+            - uv run python src/manage.py spectacular --file src/schema.yaml
+
+    schema:check:
+        desc: Fail if schema.yaml is stale versus the code (task backend:schema:check)
+        dir: backend
+        env:
+            DJANGO_ENVIRONMENT: development
+            DJANGO_DEBUG: "1"
+        cmds:
+            # Ten sam wzorzec co `db:migrations:check`: generujemy obok i porównujemy,
+            # zamiast ufać, że ktoś pamiętał o regeneracji po zmianie serializera.
+            # Rozjazd schematu nie psuje testów — wychodzi dopiero, gdy klient
+            # frontendu przestaje pasować do API.
+            #
+            # `spectacular` zapisuje schemat wyłącznie przez `--file` (bez tej flagi na
+            # stdout nie trafia nic), więc porównanie idzie przez plik obok. `defer`
+            # sprząta go także wtedy, gdy diff zwróci różnicę i zadanie padnie.
+            - uv run python src/manage.py spectacular --file .schema-check.yaml
+            - defer: rm -f .schema-check.yaml
+            - diff -u src/schema.yaml .schema-check.yaml
+
     run:
         desc: Run Django app and microservices
         cmds:


### PR DESCRIPTION
Odzyskuje pracę z PR #8 i #10, która nigdy nie dotarła do mastera.

## Co się stało

PR-y były ułożone w stack, ale zmergowano je w odwrotnej kolejności:

| czas | PR | merge |
|---|---|---|
| 20:23:06 | #6 | `fix/5-ci-green-pipeline` → `master` |
| 20:24:22 | #8 | `chore/7-schema-drift-check` → `fix/5-ci-green-pipeline` |
| 20:25:02 | #10 | `chore/9-dependabot` → `chore/7-schema-drift-check` |

`fix/5` trafił do mastera zanim #8 i #10 zdążyły do niego wejść, więc ich zmiany zostały na gałęziach.

Bezpośredni merge `chore/9-dependabot` do mastera daje konflikt — master ma tamte commity jako pojedynczy squash (`c36f21c`), a gałąź jako trzy osobne. Dlatego zamiast merge'a: gałąź z aktualnego mastera i cherry-pick dwóch brakujących commitów.

## Zawartość

- `chore(ci): detect stale OpenAPI schema` — krok `API schema up to date` w CI plus taski `backend:schema:generate` i `backend:schema:check`. Zmieniony serializer bez regeneracji schematu nie psuje żadnego testu; rozjazd wychodzi dopiero, gdy klient Orvala przestaje pasować do API.
- `chore(ci): enable Dependabot for actions, Python and Bun` — cotygodniowe aktualizacje, łatki zgrupowane, wersje Expo/React/React Native pominięte, bo idą razem z upgradem SDK.

Aktualizacja `backend/src/schema.yaml` to istniejący dryf wykryty przez nowy krok (`id: uuid`, brakujące `readOnly` na `email`).

Closes #7
Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)